### PR TITLE
Make tappable geojsons

### DIFF
--- a/components/InputComponents/AutoCompleteSearchWrapper.tsx
+++ b/components/InputComponents/AutoCompleteSearchWrapper.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { View, Keyboard, Alert } from "react-native";
-import MapView, {Region } from "react-native-maps";
+import MapView, { Region } from "react-native-maps";
 import { DefaultMapStyle } from "@/Styles/MapStyles";
 import { searchPlaces } from "@/services/PlacesService";
 import { Button } from "react-native-paper";
@@ -9,25 +9,25 @@ import { ButtonsStyles } from "@/Styles/ButtonStyles";
 import { LATITUDE_DELTA, LONGITUDE_DELTA } from "@/constants/MapsConstants";
 // The single search UI, combining autocomplete + text-based search
 export const AutocompleteSearchWrapper = ({
-    mapRef,
-    setResults,
-    userLocation,
-    currentCampus,
-    googleMapsKey,
-    location, // Accept location prop
+  mapRef,
+  setResults,
+  userLocation,
+  currentCampus,
+  googleMapsKey,
+  location, // Accept location prop
 }: {
-    mapRef: React.RefObject<MapView>;
-    setResults: React.Dispatch<React.SetStateAction<any[]>>;
-    userLocation: Region | null;
-    currentCampus: Region;
-    googleMapsKey: string;
-    location: Region | null; // Define location prop type
+  mapRef: React.RefObject<MapView>;
+  setResults: React.Dispatch<React.SetStateAction<any[]>>;
+  userLocation: Region | null;
+  currentCampus: Region;
+  googleMapsKey: string;
+  location: Region | null; // Define location prop type
 }) => {
-// This local state tracks typed text in the Autocomplete's field
-const [autoSearchText, setAutoSearchText] = useState("");
+  // This local state tracks typed text in the Autocomplete's field
+  const [autoSearchText, setAutoSearchText] = useState("");
 
-// Perform a full text-based search, returning multiple results
-const handleFullTextSearch = async () => {
+  // Perform a full text-based search, returning multiple results
+  const handleFullTextSearch = async () => {
     if (!autoSearchText.trim()) return;
 
     const boundaries = await mapRef.current?.getMapBoundaries();
@@ -45,8 +45,8 @@ const handleFullTextSearch = async () => {
     const dLon = toRad(southWest.longitude - northEast.longitude);
 
     const a =
-    Math.sin(dLat / 2) ** 2 +
-    Math.cos(toRad(northEast.latitude)) *
+      Math.sin(dLat / 2) ** 2 +
+      Math.cos(toRad(northEast.latitude)) *
         Math.cos(toRad(southWest.latitude)) *
         Math.sin(dLon / 2) ** 2;
 
@@ -56,92 +56,96 @@ const handleFullTextSearch = async () => {
     console.log('Distance between NE and SW corners (meters):', distanceMeters);
 
     try {
-    const { results, coords } = await searchPlaces(
+      const geojson = await searchPlaces(
         autoSearchText,
         userLocation?.latitude || currentCampus.latitude,
         userLocation?.longitude || currentCampus.longitude,
         googleMapsKey,
         distanceMeters
-    );
+      );
 
-    if (results.length === 0) {
+      if (geojson.features.length === 0) {
         Alert.alert("No Results", "No locations found. Try a different search.", [{ text: "OK" }]);
         return;
-    }
+      }
 
-    setResults(results);
-    if (coords.length) {
+      setResults(geojson);
+      if (geojson.features.length) {
+        const coords = geojson.features.map((feature: any) => ({
+          latitude: feature.geometry.coordinates[1],
+          longitude: feature.geometry.coordinates[0],
+        }));
         mapRef.current?.fitToCoordinates(coords, {
-        edgePadding: { top: 50, right: 50, bottom: 50, left: 50 },
-        animated: true,
+          edgePadding: { top: 50, right: 50, bottom: 50, left: 50 },
+          animated: true,
         });
         Keyboard.dismiss();
-    }
+      }
     } catch (error) {
-    console.error("Error during text search:", error);
-    Alert.alert("Error", "Failed to fetch places. Please try again.");
+      console.error("Error during text search:", error);
+      Alert.alert("Error", "Failed to fetch places. Please try again.");
     }
-};
+  };
 
-// Handle user picking a suggestion from the dropdown
-const handleSelectSuggestion = (data: GooglePlaceData, details: GooglePlaceDetail | null) => {
+  // Handle user picking a suggestion from the dropdown
+  const handleSelectSuggestion = (data: GooglePlaceData, details: GooglePlaceDetail | null) => {
     console.log("Selected place:", data, details);
     if (!details) return;
 
     const { lat, lng } = details.geometry.location;
     mapRef.current?.animateToRegion(
-    {
+      {
         latitude: lat,
         longitude: lng,
         latitudeDelta: LATITUDE_DELTA,
         longitudeDelta: LONGITUDE_DELTA,
-    },
-    1000
+      },
+      1000
     );
     // Show only this place as a result
     setResults([details]);
-};
+  };
 
-// Clear typed text and results
-const handleClearAll = () => {
+  // Clear typed text and results
+  const handleClearAll = () => {
     setAutoSearchText("");
     setResults([]);
-};
+  };
 
-return (
+  return (
     <View style={ButtonsStyles.searchWrapper}>
-    {/* The Google Places Autocomplete field */}
-    <GooglePlacesAutocomplete
+      {/* The Google Places Autocomplete field */}
+      <GooglePlacesAutocomplete
         placeholder="Search for places..."
         fetchDetails={true}
         onPress={handleSelectSuggestion}
         query={{
-        key: googleMapsKey,
-        language: "en",
-        location: location ? `${location.latitude},${location.longitude}` : undefined, // Use location for suggestions
-        radius: 50000, // 50 km radius
+          key: googleMapsKey,
+          language: "en",
+          location: location ? `${location.latitude},${location.longitude}` : undefined, // Use location for suggestions
+          radius: 50000, // 50 km radius
         }}
         textInputProps={{
-        value: autoSearchText,
-        onChangeText: setAutoSearchText,
-        onSubmitEditing: handleFullTextSearch, // Press Enter to do a multi-result search
+          value: autoSearchText,
+          onChangeText: setAutoSearchText,
+          onSubmitEditing: handleFullTextSearch, // Press Enter to do a multi-result search
         }}
         styles={{ container: { flex: 0 }, textInput: DefaultMapStyle.searchBox }}
-    />
+      />
 
-    {/* Buttons below the Autocomplete input */}
-    <View style={{ flexDirection: "row", marginTop: 10 }}>
+      {/* Buttons below the Autocomplete input */}
+      <View style={{ flexDirection: "row", marginTop: 10 }}>
         <Button
-        mode="contained"
-        onPress={handleFullTextSearch}
-        style={{ marginRight: 5, flex: 1 }}
+          mode="contained"
+          onPress={handleFullTextSearch}
+          style={{ marginRight: 5, flex: 1 }}
         >
-        Search
+          Search
         </Button>
         <Button mode="contained" onPress={handleClearAll} style={{ backgroundColor: "red", flex: 1 }}>
-        Clear
+          Clear
         </Button>
+      </View>
     </View>
-    </View>
-);
+  );
 };

--- a/screens/MapExplorerScreen.tsx
+++ b/screens/MapExplorerScreen.tsx
@@ -23,7 +23,6 @@ const hall9FloorPlan = require("@/gis/hall-9-floor-plan.json") as FeatureCollect
 
 const markerImage = require("@/assets/images/marker.png");
 
-
 const handleRoomPoiPress = (event: any) => {
   console.log("Hall 9 room POI pressed:", event);
 };
@@ -36,20 +35,17 @@ const MapComponent = ({
   userLocation,
 }: {
   mapRef: React.RefObject<MapView>;
-  results: any[];
+  results: any;
   currentCampus: Region;
-  handleMarkerPress: (marker: any) => void;
   userLocation: Region | null;
 }) => {
   const handleOutlinePress = (event: any) => {
     console.log("Building outline pressed:", event);
   };
-  
+
   const handleMarkerPress = (event: any) => {
     console.log("Building marker pressed:", event);
   };
-
-
 
   return (
     <MapView
@@ -70,7 +66,6 @@ const MapComponent = ({
         },
       ]}
     >
-      <CustomMarkersComponent data={[...results]} handleMarkerPress={handleMarkerPress} />
       <Geojson
         geojson={buildingMarkers}
         strokeColor="blue"
@@ -87,10 +82,31 @@ const MapComponent = ({
         onPress={handleOutlinePress}
         tappable={true}
       />
-
-<Geojson geojson={hall9RoomsPois} image={markerImage} strokeColor="red" fillColor="rgba(255, 0, 0, 0.5)" strokeWidth={2} tappable={true} onPress={handleRoomPoiPress} />
-      <Geojson geojson={hall9FloorPlan} strokeColor="orange" fillColor="rgba(255, 165, 0, 0.5)" strokeWidth={2} tappable={true} />
-            {userLocation && (
+      <Geojson
+        geojson={hall9RoomsPois}
+        image={markerImage}
+        strokeColor="red"
+        fillColor="rgba(255, 0, 0, 0.5)"
+        strokeWidth={2}
+        tappable={true}
+        onPress={handleRoomPoiPress}
+      />
+      <Geojson
+        geojson={hall9FloorPlan}
+        strokeColor="orange"
+        fillColor="rgba(255, 165, 0, 0.5)"
+        strokeWidth={2}
+        tappable={true}
+      />
+      {results.features && (
+        <Geojson
+          geojson={results}
+          strokeColor="red"
+          fillColor="rgba(255,0,0,0.5)"
+          strokeWidth={2}
+        />
+      )}
+      {userLocation && (
         <>
           <Circle
             center={{
@@ -116,10 +132,9 @@ const MapComponent = ({
   );
 };
 
-
 export default function MapExplorerScreen() {
   const mapRef = useRef<MapView | null>(null);
-  const [results, setResults] = useState<any[]>([]);
+  const [results, setResults] = useState<any>({});
   const [currentCampus, setCurrentCampus] = useState<Region>(SGW_CAMPUS);
   const [selectedMarker, setSelectedMarker] = useState<any>(null);
   const [showInfoBox, setShowInfoBox] = useState(false);
@@ -198,23 +213,20 @@ export default function MapExplorerScreen() {
 
   return (
     <View style={DefaultMapStyle.container}>
-      {/* Our map & markers */}
       <MapComponent
         mapRef={mapRef}
         results={results}
         currentCampus={userLocation || currentCampus}
-        handleMarkerPress={handleMarkerPress}
         userLocation={userLocation}
       />
       <View style={[ButtonsStyles.controlsContainer, MapExplorerScreenStyles.controlsContainer]}>
-        {/* Only the new GooglePlacesAutocomplete-based search */}
         <AutocompleteSearchWrapper
           mapRef={mapRef}
           setResults={setResults}
           userLocation={userLocation}
           currentCampus={currentCampus}
           googleMapsKey={googleMapsKey}
-          location={userLocation} // Pass userLocation to AutocompleteSearchWrapper
+          location={userLocation}
         />
       </View>
       <View style={[ButtonsStyles.buttonContainer, MapExplorerScreenStyles.buttonContainer]}>

--- a/screens/MapExplorerScreen.tsx
+++ b/screens/MapExplorerScreen.tsx
@@ -23,6 +23,14 @@ const hall9FloorPlan = require("@/gis/hall-9-floor-plan.json") as FeatureCollect
 
 const markerImage = require("@/assets/images/marker.png");
 
+const handleMarkerPress = (event: any) => {
+  console.log("Building marker pressed:", event);
+};
+
+const handleRoomPoiPress = (event: any) => {
+  console.log("Hall 9 room POI pressed:", event);
+};
+
 // Wrapper for the <MapView> component
 const MapComponent = ({
   mapRef,
@@ -61,7 +69,14 @@ const MapComponent = ({
       ]}
     >
       <CustomMarkersComponent data={[...results]} handleMarkerPress={handleMarkerPress} />
-      <Geojson geojson={buildingMarkers} strokeColor="blue" fillColor="cyan" strokeWidth={2} tappable={true} />
+      <Geojson
+        geojson={buildingMarkers}
+        strokeColor="blue"
+        fillColor="cyan"
+        strokeWidth={2}
+        tappable={true}
+        onPress={handleMarkerPress} // Add onPress handler
+      />
       <Geojson
         geojson={buildingOutlines}
         strokeColor="green"
@@ -71,7 +86,7 @@ const MapComponent = ({
         tappable={true}
       />
 
-<Geojson geojson={hall9RoomsPois} image={markerImage} strokeColor="red" fillColor="rgba(255, 0, 0, 0.5)" strokeWidth={2} tappable={true} />
+<Geojson geojson={hall9RoomsPois} image={markerImage} strokeColor="red" fillColor="rgba(255, 0, 0, 0.5)" strokeWidth={2} tappable={true} onPress={handleRoomPoiPress} />
       <Geojson geojson={hall9FloorPlan} strokeColor="orange" fillColor="rgba(255, 165, 0, 0.5)" strokeWidth={2} tappable={true} />
             {userLocation && (
         <>

--- a/screens/MapExplorerScreen.tsx
+++ b/screens/MapExplorerScreen.tsx
@@ -23,9 +23,6 @@ const hall9FloorPlan = require("@/gis/hall-9-floor-plan.json") as FeatureCollect
 
 const markerImage = require("@/assets/images/marker.png");
 
-const handleMarkerPress = (event: any) => {
-  console.log("Building marker pressed:", event);
-};
 
 const handleRoomPoiPress = (event: any) => {
   console.log("Hall 9 room POI pressed:", event);
@@ -36,7 +33,6 @@ const MapComponent = ({
   mapRef,
   results,
   currentCampus,
-  handleMarkerPress,
   userLocation,
 }: {
   mapRef: React.RefObject<MapView>;
@@ -48,6 +44,12 @@ const MapComponent = ({
   const handleOutlinePress = (event: any) => {
     console.log("Building outline pressed:", event);
   };
+  
+  const handleMarkerPress = (event: any) => {
+    console.log("Building marker pressed:", event);
+  };
+
+
 
   return (
     <MapView

--- a/screens/MapExplorerScreen.tsx
+++ b/screens/MapExplorerScreen.tsx
@@ -47,6 +47,10 @@ const MapComponent = ({
     console.log("Building marker pressed:", event);
   };
 
+  const handleSearchResultPress = (event: any) => {
+    console.log("Search result pressed:", event);
+  };
+
   return (
     <MapView
       ref={mapRef}
@@ -104,6 +108,8 @@ const MapComponent = ({
           strokeColor="red"
           fillColor="rgba(255,0,0,0.5)"
           strokeWidth={2}
+          tappable={true}
+          onPress={handleSearchResultPress} // Add onPress handler for search results
         />
       )}
       {userLocation && (


### PR DESCRIPTION
markers will console log on press

We need geojson markers to be fully touchable for many features:
  - getting search results as a geojson object
  - selecting search result for details
  - selecting search result for directions
  - selecting rooms
  - selecting buildings

Geojson provides very important abstractions becasue it can bundle more than just points and thus act as a way to manage layers of the map in a modular fashion and do important things like:
  - interact with them
  - style by layer
  - add/remove them from display
  - pass them as arguments or outputs
  - representing directions as one object
  - representing search results as one object
  - separation of concerns
  - strong backend-frontend boundary