### PR TITLE
fix: Revert to simple building markers with tap functionality

### DIFF
--- a/screens/MapExplorerScreen.tsx
+++ b/screens/MapExplorerScreen.tsx
@@ -183,9 +183,7 @@ const MapComponent = ({
         ]}
         onRegionChangeComplete={handleRegionChange}
       >
-        {/* {zoomLevel > BUILDING_MARKERS_ZOOM_THRESHOLD && (
-        )} */}
-        
+        {/* Building markers */}
         <Geojson
           geojson={buildingMarkers}
           strokeColor="blue"


### PR DESCRIPTION
- Revert to original Geojson implementation for building markers
- Ensure building details display properly when markers are tapped
- Remove additional label components for cleaner UI and better testing

